### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     name: Run Pre-commit Checks


### PR DESCRIPTION
Potential fix for [https://github.com/fok666/selfhosted-devops/security/code-scanning/2](https://github.com/fok666/selfhosted-devops/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions` block for the workflow or per job so that `GITHUB_TOKEN` is limited to the minimum needed scopes. For this workflow, the jobs only check out code and run local analysis tools; they do not need to write to the repository or interact with issues or pull requests. The safest minimal scope is `contents: read`.

The best fix without changing existing behavior is to add a single workflow‑level `permissions` block after the `on:` section (so it applies to all jobs unless overridden). Concretely, in `.github/workflows/pre-commit.yml`, between the trigger configuration (lines 3–5) and the `jobs:` key (line 7), insert:

```yaml
permissions:
  contents: read
```

No imports or additional methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
